### PR TITLE
cleanup + hopefully fix the user interactive shit

### DIFF
--- a/part1.sh
+++ b/part1.sh
@@ -1,9 +1,5 @@
-apt-get update
-
-apt-get install wget unzip curl libgomp1 -y
-
-#curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-#apt-get install nodejs -y
+UCF_FORCE_CONFOLD=1 DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y update
+UCF_FORCE_CONFOLD=1 DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y install unzip git python wget curl gpw libgomp1
 
 if [ ! -f /swapfile ]; then
 


### PR DESCRIPTION
User interactive shit is triggered by update/install when a lot of other packages are already installed (from other masternodes ... etc :| ). Ex. :

The following additional packages will be installed:
  gcc-8-base lib32atomic1 lib32gcc1 lib32gomp1 lib32itm1 lib32mpx2
  lib32quadmath0 lib32stdc++6 libatomic1 libcc1-0 libcurl4 libgcc1 libitm1
  liblsan0 libmpx2 libquadmath0 libssl1.1 libstdc++6 libtsan0 libx32atomic1
  libx32gcc1 libx32gomp1 libx32itm1 libx32quadmath0 libx32stdc++6
The following packages will be upgraded:
  curl gcc-8-base lib32atomic1 lib32gcc1 lib32gomp1 lib32itm1 lib32mpx2
  lib32quadmath0 lib32stdc++6 libatomic1 libcc1-0 libcurl4 libgcc1 libgomp1
  libitm1 liblsan0 libmpx2 libquadmath0 libssl1.1 libstdc++6 libtsan0
  libx32atomic1 libx32gcc1 libx32gomp1 libx32itm1 libx32quadmath0
  libx32stdc++6 wget
28 upgraded, 0 newly installed, 0 to remove and 276 not upgraded.
...
...
Configuring libssl1.1:amd64

---------------------------

There are services installed on your system which need to be restarted when 
certain libraries, such as libpam, libc, and libssl, are upgraded. Since these 
restarts may cause interruptions of service for the system, you will normally be
prompted on each upgrade for the list of services you wish to restart.  You can 
choose this option to avoid being prompted; instead, all necessary restarts will
be done for you automatically so you can avoid being asked questions on each
library upgrade.

Restart services during package upgrades without asking? [yes/no] 
------------------------------------------------------------------------
And here ^^ the automation is sent to /dev/null :|